### PR TITLE
fix: css in Layout to hide the scroll bar

### DIFF
--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -124,8 +124,8 @@ const Layout: React.FC = () => {
   ];
 
   const drawer = (
-    <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
-      <List sx={{ flexGrow: 1 }}>
+    <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column', overflowX: 'hidden' }}>
+      <List sx={{ flexGrow: 1, overflowX: 'hidden' }}>
         {menuItems.map((item) => {
           const isActive = location.pathname === item.path || (item.path === '/' && location.pathname === '');
           return (
@@ -312,6 +312,7 @@ const Layout: React.FC = () => {
               background: themeMode === 'dark' ? '#1e1e1e' : '#fff',
               color: themeMode === 'dark' ? '#fff' : 'inherit',
               borderRight: themeMode === 'dark' ? '1px solid rgba(255, 255, 255, 0.12)' : '1px solid rgba(0, 0, 0, 0.12)',
+              overflowX: 'hidden',
             },
           }}
         >


### PR DESCRIPTION
Fix: hide scroll bar

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Hide horizontal scrollbar in the sidebar by setting overflowX: 'hidden' on drawer container, list, and Drawer paper.
> 
> - **Frontend (Layout)**:
>   - **Navigation Drawer**:
>     - Set `overflowX: 'hidden'` on drawer container `Box` and `List` to prevent horizontal scrolling.
>     - Add `overflowX: 'hidden'` to `& .MuiDrawer-paper` styles to hide horizontal scrollbar.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98d74da5d6d27d83b38cc85ce10008c03d33544a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->